### PR TITLE
Add 'message' input instead of `successMessage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Create a `workflow.yml` file in your repository's `.github/workflows` directory.
 
 For more information on these inputs, see the [API Documentation](https://developer.github.com/v3/repos/releases/#input-2)
 
-- `successMessage`: The message to post on a successful status
-- `failureMessage`: The message to post on a failure status
-- `stepStatus`: The status of the previous (or any) step to trigger the message
+- `message`: The message to post on a successful status, if no other input parameters are identified, then the action will assume that this message should be posted unaltered.  Otherwise it wraps a success or failure emoji
+- `failureMessage`: Optional: The message to post on a failure status.  Mandatory if using stepStatus
+- `stepStatus`: Optional: The status of the previous (or any) step to trigger the message
 - `successLabel`: Optional: The label to add to the issue on success
 - `failureLabel`: Optional: The label to add to the issue on failure
 - `mentions`: Optional: The Comma separated list of users to notify on failure
@@ -63,7 +63,7 @@ jobs:
       - name: Comment on Issue
         uses: ActionsDesk/add-comment-action@master
         with:
-           successMessage: ${{ steps.invite_user.outputs.message }}
+           message: ${{ steps.invite_user.outputs.message }}
            failureMessage: ${{ steps.invite_user.outputs.message }}
            stepStatus: ${{ steps.invite_user.outputs.stepStatus }}
            successLabel: 'processed'
@@ -71,6 +71,25 @@ jobs:
            mentions: 'Chocrates,Chocrates2'
         env: 
           GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+```
+
+### Example workflow - Add comment on a new issue unaltered
+```yaml
+name: Comment on new Issue
+
+on: 
+   issues:
+     types: [opened]
+jobs:
+  add-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on Issue
+        uses: ActionsDesk/add-comment-action@master
+        with:
+           message: 'Welcome to the repository!'
+        env:
+          GITHUB_TOKEN: ${{ secrest.ADMIN_TOKEN }}
 ```
 
 This will workflow will create a new organization invitation for the user information found in the issue body.

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -17,9 +17,30 @@ beforeAll(() => {
   };
   octomock.updateContext(context);
 });
+
 test('Main', async () => {
   await run();
-
   expect(octomock.mockFunctions.getInput).toHaveBeenCalledTimes(6);
   expect(octomock.mockFunctions.createComment).toHaveBeenCalled();
+});
+
+test('No status doesnt format message', async () => {
+    const message = 'I am a message'
+
+    octomock.getCoreImplementation().getInput.mockImplementation((param: string) => {
+        switch(param){
+            case 'message': return message;
+            default: return undefined;
+        }
+    })
+
+    await run();
+    expect(octomock.mockFunctions.getInput).toHaveBeenCalledTimes(6);
+    expect(octomock.mockFunctions.createComment).toHaveBeenCalledWith({
+        body: message,
+        issue_number: 1,
+        owner: 'ezra',
+        repo: 'loth-cat-pen-monitor'
+    });
+    expect(octomock.mockFunctions.addLabels).toHaveBeenCalledTimes(0);
 });

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -25,22 +25,26 @@ test('Main', async () => {
 });
 
 test('No status doesnt format message', async () => {
-    const message = 'I am a message'
+  const message = 'I am a message';
 
-    octomock.getCoreImplementation().getInput.mockImplementation((param: string) => {
-        switch(param){
-            case 'message': return message;
-            default: return undefined;
-        }
-    })
-
-    await run();
-    expect(octomock.mockFunctions.getInput).toHaveBeenCalledTimes(6);
-    expect(octomock.mockFunctions.createComment).toHaveBeenCalledWith({
-        body: message,
-        issue_number: 1,
-        owner: 'ezra',
-        repo: 'loth-cat-pen-monitor'
+  octomock
+    .getCoreImplementation()
+    .getInput.mockImplementation((param: string) => {
+      switch (param) {
+        case 'message':
+          return message;
+        default:
+          return undefined;
+      }
     });
-    expect(octomock.mockFunctions.addLabels).toHaveBeenCalledTimes(0);
+
+  await run();
+  expect(octomock.mockFunctions.getInput).toHaveBeenCalledTimes(6);
+  expect(octomock.mockFunctions.createComment).toHaveBeenCalledWith({
+    body: message,
+    issue_number: 1,
+    owner: 'ezra',
+    repo: 'loth-cat-pen-monitor'
+  });
+  expect(octomock.mockFunctions.addLabels).toHaveBeenCalledTimes(0);
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import {
 
 async function run(): Promise<void> {
   try {
-    const successMessage: string = core.getInput('successMessage');
+    const message: string = core.getInput('message');
     const failureMessage: string = core.getInput('failureMessage');
     const status: string = core.getInput('stepStatus');
     const successLabel: string = core.getInput('successLabel');
@@ -27,11 +27,16 @@ async function run(): Promise<void> {
       const {owner, name: repo} = getRepoData(repository);
       const {number} = getIssueData(issue);
       const mentionsList = mentions ? mentions.split(',') : undefined;
-      const body = createIssueComment(
-        isSuccessful(status) ? successMessage : failureMessage,
-        status,
-        mentionsList
-      );
+        let body;
+      if(status) {
+        body = createIssueComment(
+            isSuccessful(status) ? message : failureMessage,
+            status,
+            mentionsList
+        );
+      } else {
+          body = message;
+      }
 
       await octokit.issues.createComment({
         body,

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,15 +27,15 @@ async function run(): Promise<void> {
       const {owner, name: repo} = getRepoData(repository);
       const {number} = getIssueData(issue);
       const mentionsList = mentions ? mentions.split(',') : undefined;
-        let body;
-      if(status) {
+      let body;
+      if (status) {
         body = createIssueComment(
-            isSuccessful(status) ? message : failureMessage,
-            status,
-            mentionsList
+          isSuccessful(status) ? message : failureMessage,
+          status,
+          mentionsList
         );
       } else {
-          body = message;
+        body = message;
       }
 
       await octokit.issues.createComment({


### PR DESCRIPTION
Changing the inputs around so we can add an unformatted message to an issue if we want.